### PR TITLE
Increased elemental resistances and fixed droprates.

### DIFF
--- a/sql/melfsql/rhos_changes.sql
+++ b/sql/melfsql/rhos_changes.sql
@@ -4,3 +4,9 @@ UPDATE mob_spawn_points SET pos_x=124, pos_y=19, pos_z=163, pos_rot=100 WHERE mo
 -- Correct droplist for Thread Leeches (in Pashhow Marshlands, zoneID = 109)
 -- (poolid = 5133; vial of beastman's blood = 930; dropid = 3472; vial of fiend blood = 924)
 DELETE FROM mob_droplist WHERE dropId=3472 AND itemId=924;
+
+-- Adjust Dread Dealing Dredodak's Spawn Point
+UPDATE mob_spawn_points SET pos_x=-137, pos_y=7.57, pos_z=146 WHERE mobId=16822462;
+
+-- Buff the Dragon Family (+STR, +Elemental Resistance)
+UPDATE mob_family_system SET STR=3, Light=.9, Dark=.75, Fire=.9, Ice=.9, Water=.9, Lightning=.9, Earth=.9, Wind=.9 WHERE family="Dragon";

--- a/sql/melfsql/rhos_cop.sql
+++ b/sql/melfsql/rhos_cop.sql
@@ -1,5 +1,25 @@
--- Delver, Progenerator, and Wreaker level increase
-UPDATE mob_groups SET minLevel=35, maxLevel=36 WHERE groupid=512 OR groupid=485 OR groupid=502;
-
--- Make Delver, Progenerator, and Wreaker NMs (check -> impossible to gauge)
+-- Delver, Progenerator, and Wreaker /check -> impossible to gauge
 UPDATE mob_pools SET mobType=18 WHERE poolid=966 OR poolid=3204 OR poolid=4382;
+
+-- Craver Family Adjustments
+UPDATE mob_groups SET minLevel=35, maxLevel=36 WHERE groupid=512;
+UPDATE mob_family_system SET Light=.75, Dark=.75, Fire=.75, Ice=.75, Water=.75, Lightning=.75, Earth=.75, Wind=.75 WHERE family="Craver"; -- Increase Elemental resistance
+
+-- Gorger Family Adjustments
+UPDATE mob_groups SET minLevel=35, maxLevel=36 WHERE groupid=485;
+UPDATE mob_family_system SET Light=.75, Dark=.75, Fire=.75, Ice=.75, Water=.75, Lightning=.75, Earth=.75, Wind=.75 WHERE family="Gorger"; -- Increase Elemental Resistance
+
+-- Thinker Family Adjustments
+UPDATE mob_groups SET minLevel=35, maxLevel=36 WHERE groupid=502;
+UPDATE mob_family_system SET Light=.75, Dark=.75, Fire=.75, Ice=.75, Water=.75, Lightning=.75, Earth=.75, Wind=.75 WHERE family="Thinker"; -- Increase Elemental Resistance
+
+-- Create separate droplist for Gigantobugards in Lufaise Meadows (zoneID = 24)
+INSERT INTO mob_droplist VALUES (4523,0,1680,10);	--  HQ Bugard Skin: 1%
+INSERT INTO mob_droplist VALUES (4523,0,1640,450);	--  Bugard Skin: 45%
+INSERT INTO mob_droplist VALUES (4523,0,1622,30);	--  Bugard Tusk: 3%
+UPDATE mob_groups SET dropid=4523 WHERE groupid=587;
+
+-- Correct droprates for Gigantobugards in Misreaux Coast (zoneID = 25)
+UPDATE mob_droplist SET rate=80 WHERE dropId=1144 AND itemId=1622;	--  Bugard Tusk: 8%
+UPDATE mob_droplist SET rate=150 WHERE dropId=1144 AND itemId=1680;	--  HQ Bugard Skin: 15%
+UPDATE mob_droplist SET rate=500 WHERE dropId=1144 AND itemId=1640;	--  Bugard Skin: 50%


### PR DESCRIPTION
Gigantobugard droprates are fixed. Dragon family has increased strength and +10% elemental resistances (+25% dark resistance). Promy-Holla/Mea/Dem bosses have +25% elemental resistances (bind lasted almost the entire fight, were killable by a blm duo).
